### PR TITLE
This fixes the auto-loaded lightboxes

### DIFF
--- a/src/library/components/materials-collection.js
+++ b/src/library/components/materials-collection.js
@@ -2,6 +2,7 @@ var Component = require('../helpers/component');
 var ResourceLightbox = require('./resource-lightbox');
 var shuffleArray = require('../helpers/shuffle-array');
 var filters = require("../helpers/filters");
+var Lightbox = require ("../helpers/lightbox")
 
 var a = React.DOM.a;
 var div = React.DOM.div;
@@ -39,44 +40,20 @@ var MaterialsCollectionItem = Component({
     e.stopPropagation();
     var lightbox = !this.state.lightbox;
 
-    // TODO: add pushstate
     this.setState({
       lightbox: lightbox,
       hovering: false
     });
 
     // mount/unmount lightbox outside of homepage content
-    var mountPointId = "stem-finder-result-lightbox-mount";
-    var mountPoint = document.getElementById(mountPointId);
     if (lightbox) {
-      if (!mountPoint) {
-        mountPoint = document.createElement("DIV");
-        mountPoint.id = mountPointId;
-        document.body.appendChild(mountPoint);
-      }
-      jQuery('html, body').css('overflow', 'hidden');
-      ReactDOM.render(ResourceLightbox({resource: this.props.item, toggleLightbox: this.toggleLightbox}), mountPoint);
-      jQuery('<div class="portal-pages-resource-lightbox-background"></div>').insertBefore('#stem-finder-result-lightbox-mount');
-      jQuery('.portal-pages-resource-lightbox-background').click(function() {
-        ResourceLightbox.handleClose(); // this doesn't work
-      });
-      jQuery('.home-page-content').addClass('blurred');
-      jQuery('.portal-pages-resource-lightbox-background, #stem-finder-result-lightbox-mount').fadeIn();
+      var resourceLightbox =
+        ResourceLightbox({resource: this.props.item, toggleLightbox: this.toggleLightbox});
+      Lightbox.open(resourceLightbox);
     }
     else {
-      jQuery('html, body').css('overflow', 'auto');
-      ReactDOM.unmountComponentAtNode(mountPoint);
-      jQuery('.portal-pages-resource-lightbox-background').remove();
-      jQuery('.home-page-content').removeClass('blurred');
-      jQuery('.portal-pages-resource-lightbox-background, #stem-finder-result-lightbox-mount').fadeOut();
+      Lightbox.close();
     }
-  },
-
-  renderLightbox: function () {
-    if (!this.state.lightbox) {
-      return null;
-    }
-    return ResourceLightbox({resource: this.props.item, toggleLightbox: this.toggleLightbox});
   },
 
   render: function () {

--- a/src/library/components/resource-lightbox.js
+++ b/src/library/components/resource-lightbox.js
@@ -21,19 +21,36 @@ var ResourceLightbox = Component({
     };
   },
 
+  getDefaultProps: function () {
+    return {
+      savedUrl: location.toString(),
+      savedTitle: document.title
+    };
+  },
+
   componentWillMount: function () {
-    this.savedUrl = location.toString();
-    this.savedTitle = document.title;
+    jQuery('html, body').css('overflow', 'hidden');
+    jQuery('.home-page-content').addClass('blurred');
+
     this.titleSuffix = document.title.split("|")[1] || "";
     this.replaceResource(this.props.resource);
   },
 
+  componentDidMount: function () {
+    jQuery('.portal-pages-resource-lightbox-background, .portal-pages-resource-lightbox-container').fadeIn();
+  },
+
   componentWillUnmount: function () {
-    document.title = this.savedTitle;
+    document.title = this.props.savedTitle;
     try {
-      history.replaceState({}, document.title, this.savedUrl);
+      history.replaceState({}, document.title, this.props.savedUrl);
     }
     catch (e) {}
+    jQuery('html, body').css('overflow', 'auto');
+    jQuery('.home-page-content').removeClass('blurred');
+
+    // FIXME: Not sure if this is going to work because the component will be removed
+    jQuery('.portal-pages-resource-lightbox-background, .portal-pages-resource-lightbox-container').fadeOut();
   },
 
   replaceResource: function (resource) {
@@ -243,12 +260,17 @@ var ResourceLightbox = Component({
 
   render: function () {
     var resource = this.state.resource;
-    return div({className: "portal-pages-resource-lightbox", onClick: this.handleClose},
-      div({className: "portal-pages-resource-lightbox-background-close", onClick: this.handleClose}, "x"),
-      div({className: "portal-pages-resource-lightbox-modal"},
-        resource ? this.renderResource() : this.render404()
-      ),
-      resource ? this.renderSharing() : null
+    return div({},
+      div({className: "portal-pages-resource-lightbox-background"}),
+      div({className: "portal-pages-resource-lightbox-container"},
+        div({className: "portal-pages-resource-lightbox", onClick: this.handleClose},
+          div({className: "portal-pages-resource-lightbox-background-close", onClick: this.handleClose}, "x"),
+          div({className: "portal-pages-resource-lightbox-modal"},
+            resource ? this.renderResource() : this.render404()
+          ),
+          resource ? this.renderSharing() : null
+        )
+      )
     );
   }
 });

--- a/src/library/components/stem-finder-result.js
+++ b/src/library/components/stem-finder-result.js
@@ -9,6 +9,7 @@ var sortByName = require("../helpers/sort-by-name");
 var pluralize = require("../helpers/pluralize");
 var randomSubset = require("../helpers/random-subset");
 var filters = require("../helpers/filters");
+var Lightbox = require ("../helpers/lightbox")
 
 var div = React.DOM.div;
 var img = React.DOM.img;
@@ -43,36 +44,21 @@ var StemFinderResult = Component({
     e.stopPropagation();
     var lightbox = !this.state.lightbox;
 
-    // TODO: add pushstate
     this.setState({
       lightbox: lightbox,
       hovering: false
     });
 
     // mount/unmount lightbox outside of homepage content
-    var mountPointId = "stem-finder-result-lightbox-mount";
-    var mountPoint = document.getElementById(mountPointId);
     if (lightbox) {
-      if (!mountPoint) {
-        mountPoint = document.createElement("DIV");
-        mountPoint.id = mountPointId;
-        document.body.appendChild(mountPoint);
-      }
-      jQuery('html, body').css('overflow', 'hidden');
-      ReactDOM.render(ResourceLightbox({resource: this.props.resource, toggleLightbox: this.toggleLightbox}), mountPoint);
-      jQuery('<div class="portal-pages-resource-lightbox-background"></div>').insertBefore('#stem-finder-result-lightbox-mount');
-      jQuery('.portal-pages-resource-lightbox-background').click(function() {
-        ResourceLightbox.handleClose(); // this doesn't work
+      var resourceLightbox = ResourceLightbox({
+        resource: this.props.resource,
+        toggleLightbox: this.toggleLightbox
       });
-      jQuery('.home-page-content').addClass('blurred');
-      jQuery('.portal-pages-resource-lightbox-background, #stem-finder-result-lightbox-mount').fadeIn();
+      Lightbox.open(resourceLightbox);
     }
     else {
-      jQuery('html, body').css('overflow', 'auto');
-      ReactDOM.unmountComponentAtNode(mountPoint);
-      jQuery('.portal-pages-resource-lightbox-background').remove();
-      jQuery('.home-page-content').removeClass('blurred');
-      jQuery('.portal-pages-resource-lightbox-background, #stem-finder-result-lightbox-mount').fadeOut();
+      Lightbox.close();
     }
   },
 
@@ -99,13 +85,6 @@ var StemFinderResult = Component({
     else {
       jQuery.post('/api/v1/materials/add_favorite', {id: resource.id, type: resource.class_name_underscored}, done);
     }
-  },
-
-  renderLightbox: function () {
-    if (!this.state.lightbox) {
-      return null;
-    }
-    return ResourceLightbox({resource: this.props.resource, toggleLightbox: this.toggleLightbox});
   },
 
   renderFavoriteStar: function () {

--- a/src/library/helpers/lightbox.js
+++ b/src/library/helpers/lightbox.js
@@ -1,0 +1,32 @@
+/*
+This is just a small reusable bit of code for mounting and unmounting a react component
+in a new part of the document. The actual lightbox functionality is in resource-lightbox.
+
+WARNING: Currently when the portal renders a URL for a lightbox resource it does not use
+this object. The portal creates its own dom element and calls ReactDOM.render itself.
+So any functionality you add to this object will probably need to be copied there too.
+Code in ResourceLightbox is called in either case so it is better place to put things.
+*/
+var Lightbox = {
+  mountPointId: "portal-pages-lightbox-mount",
+
+  open: function(component) {
+    var mountPoint = document.getElementById(this.mountPointId);
+
+    if (!mountPoint) {
+      mountPoint = document.createElement("DIV");
+      mountPoint.id = this.mountPointId;
+      document.body.appendChild(mountPoint);
+    }
+    ReactDOM.render(component, mountPoint);
+  },
+
+  close: function() {
+    var mountPoint = document.getElementById(this.mountPointId);
+
+    ReactDOM.unmountComponentAtNode(mountPoint);
+  }
+
+};
+
+module.exports = Lightbox;

--- a/src/library/library.scss
+++ b/src/library/library.scss
@@ -201,7 +201,7 @@
   width: 100%;
 }
 
-#stem-finder-result-lightbox-mount {
+.portal-pages-resource-lightbox-container {
   display: none;
   height: 100%;
   left: 0;
@@ -209,7 +209,8 @@
   position: fixed;
   top: 0;
   width: 100%;
-  }
+}
+
 .portal-pages-resource-lightbox {
   box-sizing: content-box;
   bottom: auto;


### PR DESCRIPTION
These auto-loaded lightboxes are shown when a URL is loaded directly with the stem resource URL.
It moves the code for the lightbox divs into resource-lightbox component. The portal does not
use a stem-finder-result to render one of these lightboxes. So by moving the code into
resource-lightbox the code is shared by both.

There are still issues with this:
- scroll position: when a lightbox is opened from a card near the bottom of the page and then the page
  is reloaded. When the lightbox is closed it is confusing for the user.
- flash of content: when a lightbox is shown automatically by the portal the background content shows
  up quickly and then disappears.

[#150383056]