### PR TITLE
Require Home Page Content author to render embedded signup form with …

### DIFF
--- a/src/library/components/signup/basic_data_form.js
+++ b/src/library/components/signup/basic_data_form.js
@@ -108,6 +108,11 @@ var BasicDataForm = function() {
         providers = this.props.oauthProviders;
         providers.sort(function(a,b) { return (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0); } ); // sort providers alphabetically by name 
         for(var i = 0; i < providers.length; i++) {
+          if(i == 0) {
+            providerComponents.push(
+              p({}, 'Sign up with: ')
+            );
+          }
           // console.log("INFO adding provider direct path " + providers[i].directPath);
           // console.log("INFO adding provider auth check path " + providers[i].authCheckPath);
 
@@ -140,7 +145,6 @@ var BasicDataForm = function() {
         onChange: this.onChange
       },
       div({className: 'third-party-login-options'},
-        p({}, 'Sign up with: '),
         providerComponents
       ),
       anonymous ? div({},

--- a/src/library/components/signup/signup.js
+++ b/src/library/components/signup/signup.js
@@ -191,7 +191,7 @@ var Signup = function() {
             [strong({},'Finish'), ' Signing Up']
         ),
         div({className: 'signup-form'}, form),
-        footer({},
+        footer({className: "reg-footer"},
           p({},
             strong({}, 'Why sign up?'),
             " It's free and you get access to several key features, like creating classes for your students, assigning activities, saving work, tracking student progress, and more!"

--- a/src/library/library.scss
+++ b/src/library/library.scss
@@ -737,4 +737,45 @@ $materials-collection-item-icon-width: 300px;
   padding: 0 10px;
 }
 
+.embedded-signup-class {
+
+  position: absolute;
+  display: inline-block;
+  width: 45%;
+
+  top:      0px;
+  right:    0px;
+  
+  font-size: inherit;
+
+  .step {
+    position: absolute;
+    display: inline-block;
+    top: 0px;
+    right: 0px;
+  }
+
+  .text-input {
+    width: 100%;
+  }
+
+  .reg-footer {
+    display: none
+  }
+
+  .first-name-wrapper {
+    width: 100%;
+  }
+
+  .last-name-wrapper {
+    width: 100%;
+  }
+
+  .last_name {
+    margin-left: 0%;
+  }
+
+}
+
+
 @import './styles/_media_queries.scss';

--- a/src/site-redesign/styles/_portal-restyling.scss
+++ b/src/site-redesign/styles/_portal-restyling.scss
@@ -35,5 +35,5 @@
 }
 
 #notice_container, .project_cards, .result_material {
-  display: none;
+  display: block;
 }


### PR DESCRIPTION
…PortalPages API.

[#150607212]

This is what the embedded form looks like. (See attached.)
<img width="621" alt="screen shot 2017-08-29 at 11 43 09 am" src="https://user-images.githubusercontent.com/27232646/29838393-f60ab5b0-8caf-11e7-9bad-db511a523eb7.png">

If we want additional styling maybe Ethan can take a look? I don't want to break any of the styling used for the main flow on the new modal signup widget while trying to support this somewhat legacy flow. (Plus they still have a modal option with the link from the banner anyway.)

