### PR TITLE
Refactor handling of short and long descriptions in portal-pages

### DIFF
--- a/src/library/components/collection-cards.js
+++ b/src/library/components/collection-cards.js
@@ -4,6 +4,7 @@ var fadeIn = require("../helpers/fade-in");
 var sortByName = require("../helpers/sort-by-name");
 var shuffleArray = require("../helpers/shuffle-array");
 var waitForAutoShowingLightboxToClose = require("../helpers/wait-for-auto-lightbox-to-close");
+var portalObjectHelpers = require("../helpers/portal-object-helpers");
 
 var div = React.DOM.div;
 var a = React.DOM.a;
@@ -25,11 +26,9 @@ var CollectionCards = Component({
         url: "/api/v1/projects",  // TODO: replace with Portal.API_V1 constant when available
         dataType: "json"
       }).done(function (data) {
-        var descriptionFilter = document.createElement("DIV");
         var collections = data.reduce(function (collections, collection) {
           if (collection.public && collection.landing_page_slug) {
-            descriptionFilter.innerHTML = collection.project_card_description;
-            collection.filteredDescription = descriptionFilter.innerText;
+            collection.filteredDescription = portalObjectHelpers.textOfHtml(collection.project_card_description);
             collections.push(collection);
           }
           return collections;

--- a/src/library/components/materials-collection.js
+++ b/src/library/components/materials-collection.js
@@ -2,6 +2,7 @@ var Component = require('../helpers/component');
 var ResourceLightbox = require('./resource-lightbox');
 var shuffleArray = require('../helpers/shuffle-array');
 var filters = require("../helpers/filters");
+var portalObjectHelpers = require("../helpers/portal-object-helpers");
 var Lightbox = require ("../helpers/lightbox");
 var ResourceType = require("./resource-type");
 
@@ -20,6 +21,11 @@ var MaterialsCollectionItem = Component({
       hovering: false,
       lightbox: false
     };
+  },
+
+  componentWillMount: function () {
+    var item = this.props.item;
+    portalObjectHelpers.processResource(item);
   },
 
   handleMouseOver: function () {
@@ -72,7 +78,8 @@ var MaterialsCollectionItem = Component({
             item.name
           )
         ),
-        div({className: "portal-pages-finder-materials-collection-item__description", dangerouslySetInnerHTML: {__html: item.description}})
+        div({className: "portal-pages-finder-materials-collection-item__description"},
+          item.filteredShortDescription)
       )
       //pre({}, JSON.stringify(this.props.item, null, 2))
     );

--- a/src/library/components/related-resource-result.js
+++ b/src/library/components/related-resource-result.js
@@ -1,6 +1,7 @@
 var GradeLevels = require("./grade-levels");
 var Component = require('../helpers/component');
 var filters = require("../helpers/filters");
+var portalObjectHelpers = require("../helpers/portal-object-helpers");
 
 var div = React.DOM.div;
 var img = React.DOM.img;
@@ -13,13 +14,9 @@ var RelatedResourceResult = Component({
   },
 
   componentWillMount: function () {
-    // filter the description if not already done
+    // process the related resource
     var resource = this.props.resource;
-    if (!resource.filteredDescription) {
-      var descriptionFilter = document.createElement("DIV");
-      descriptionFilter.innerHTML = resource.description;
-      resource.filteredDescription = descriptionFilter.innerText;
-    }
+    portalObjectHelpers.processResource(resource);
   },
 
   handleClick: function (e) {
@@ -42,7 +39,7 @@ var RelatedResourceResult = Component({
 
     if (this.state.hovering) {
       return div(options,
-        div({className: "portal-pages-finder-result-description"}, resource.filteredDescription),
+        div({className: "portal-pages-finder-result-description"}, resource.filteredShortDescription),
         GradeLevels({resource: resource})
       );
     }

--- a/src/library/components/resource-lightbox.js
+++ b/src/library/components/resource-lightbox.js
@@ -1,6 +1,7 @@
 var Component = require('../helpers/component');
 var RelatedResourceResult = require("./related-resource-result");
 var pluralize = require("../helpers/pluralize");
+var portalObjectHelpers = require("../helpers/portal-object-helpers");
 
 var div = React.DOM.div;
 var img = React.DOM.img;
@@ -32,8 +33,13 @@ var ResourceLightbox = Component({
     jQuery('html, body').css('overflow', 'hidden');
     jQuery('.home-page-content').addClass('blurred');
 
+    var resource = this.props.resource;
+    // If the lightbox is shown directly the resource might not have been
+    // processed yet
+    portalObjectHelpers.processResource(resource);
+
     this.titleSuffix = document.title.split("|")[1] || "";
-    this.replaceResource(this.props.resource);
+    this.replaceResource(resource);
   },
 
   componentDidMount: function () {
@@ -252,7 +258,7 @@ var ResourceLightbox = Component({
           img({src: resource.icon.url})
         ),
         h1({}, resource.name),
-        p({className: "portal-pages-resource-lightbox-description"}, resource.filteredDescription),
+        p({className: "portal-pages-resource-lightbox-description"}, resource.filteredLongDescription),
         div({},
           links.preview ? a({className: "portal-pages-primary-button", href: links.preview.url, target: "_blank"}, links.preview.text) : null,
           links.assign_material ? a({className: "portal-pages-secondary-button", href: 'javascript:' + links.assign_material.onclick}, links.assign_material.text) : null,

--- a/src/library/components/stem-finder-result.js
+++ b/src/library/components/stem-finder-result.js
@@ -102,7 +102,7 @@ var StemFinderResult = Component({
     if (this.state.hovering || this.state.lightbox) {
       return div({className: "portal-pages-finder-result col-4", onClick: this.toggleLightbox, onMouseOver: this.handleMouseOver, onMouseOut: this.handleMouseOut},
         a(options,
-          div({className: "portal-pages-finder-result-description"}, resource.filteredDescription),
+          div({className: "portal-pages-finder-result-description"}, resource.filteredShortDescription),
           this.renderFavoriteStar()
         ),
         GradeLevels({resource: resource}),

--- a/src/library/components/stem-finder.js
+++ b/src/library/components/stem-finder.js
@@ -10,6 +10,7 @@ var fadeIn = require("../helpers/fade-in");
 var pluralize = require("../helpers/pluralize");
 var waitForAutoShowingLightboxToClose = require("../helpers/wait-for-auto-lightbox-to-close");
 var filters = require("../helpers/filters");
+var portalObjectHelpers = require("../helpers/portal-object-helpers");
 
 var a = React.DOM.a;
 var div = React.DOM.div;
@@ -131,8 +132,7 @@ var StemFinder = Component({
 
       results.forEach(function (result) {
         result.materials.forEach(function (material) {
-          descriptionFilter.innerHTML = material.description;
-          material.filteredDescription = descriptionFilter.innerText;
+          portalObjectHelpers.processResource(material);
           resources.push(material);
           lastSearchResultCount++;
         });

--- a/src/library/helpers/portal-object-helpers.js
+++ b/src/library/helpers/portal-object-helpers.js
@@ -1,0 +1,72 @@
+var filterDiv = null;
+
+var shortenText = function(text, length) {
+  length = (typeof length !== 'undefined') ? length : 255;
+  if (!text) {
+    return "";
+  } else {
+    if (text.length > length) {
+      return text.substring(0, length-6) + "…" + text.substring(text.length-5);
+    } else {
+      return text;
+    }
+  }
+};
+
+var textOfHtml = function (text) {
+  if (!filterDiv) {
+    filterDiv = document.createElement("DIV");
+  }
+
+  filterDiv.innerHTML = text;
+  return filterDiv.innerText;
+};
+
+/*
+   The resource.description is setup by the portal. It is not the same as the description
+   field stored in the database. The portal uses this logic:
+   - if the user is a teacher and there is a description_for_teacher, then the
+     description is the description_for_teacher
+   - else if there is an abstract, then the description is the abstract
+   - finally if the other two cases don't apply then the description is the
+     actual description shortened to 255 characters.
+
+   Portal v1.19.0-pre.12 added the following fields:
+   - resource.full_description - description database value, "" otherwise
+   - resource.abstact - database value if it exists, "" otherwise
+   - resource.description_for_teacher - database value if it exists, "" otherwise
+*/
+var processResource = function (resource) {
+  if (resource._processed) {
+    return;
+  }
+
+  resource.filteredDescription = textOfHtml(resource.description);
+
+  var shortDescription;
+  if (resource.abstract) {
+    shortDescription = resource.abstract;
+  } else if (resource.full_description) {
+    shortDescription = shortenText(resource.full_description);
+  } else {
+    shortDescription = resource.description
+  }
+  resource.filteredShortDescription = textOfHtml(shortDescription);
+
+  var longDescription;
+  if (Portal.currentUser.isTeacher && resource.description_for_teacher){
+    longDescription = resource.description_for_teacher;
+  } else if (resource.full_description) {
+    longDescription = resource.full_description;
+  } else {
+    longDescription = resource.description;
+  }
+  resource.filteredLongDescription = textOfHtml(longDescription);
+
+  resource._processed = true;
+};
+
+module.exports = {
+  textOfHtml: textOfHtml,
+  processResource: processResource
+}


### PR DESCRIPTION
This is designed to be backward compatible with older portals.
The new portal code will provide the actual (full) description, abstract, and description_for_teacher
When these are available portal_pages uses them to figure out the best thing to show.
The old portal code only provides the processed description, in this case portal_pages uses
this processed description everywhere.

[#150674559]
[#150414194]
[#150535877]
[#150675559]