### PR TITLE
Speed up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js: node
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js: node
 install:
-- travis_retry gem install s3_website -v 2.12.3
+- travis_retry gem install s3_website -v 3.4.0
 - travis_retry npm install
 before_script: npm run build
 script: ./s3_deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js: node
-before_install:
-- rvm install 2.2.0
 install:
 - travis_retry gem install s3_website -v 2.12.3
 - travis_retry npm install

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -27,4 +27,4 @@ cloudfront_distribution_config:
   aliases:
     quantity: 1
     items:
-      CNAME0: portal-pages.concord.org
+      - portal-pages.concord.org


### PR DESCRIPTION
Removing the explicit 2.2 install of ruby seems to work and really speeds up the build.

@dougmartin do you know any reason why that specific version of ruby has been used when running s3_website?