### PR TITLE
switch to strict mode broke the standards rendering

### DIFF
--- a/src/library/helpers/standards-helpers.js
+++ b/src/library/helpers/standards-helpers.js
@@ -306,7 +306,7 @@ var NgssHelper = function () {
  *
  */
 var getStandardsHelper = function (standardType) {
-  if (standardType === 'NGSS') { return NgssHelper() }
+  if (standardType === 'NGSS') { return new NgssHelper() }
 }
 
 module.exports = {


### PR DESCRIPTION
Note this was a good thing to find because it was polluting window object

To test it locally you need to add standards to an external activity.
To add standards you need to setup your ASN key and also run:
`docker-compose run --rm app bundle exec rake app:setup:create_standard_documents`

[#157406155]
PT story: https://www.pivotaltracker.com/n/projects/736901/stories/157406155

