### PR TITLE
Support of non-LARA external activities

### DIFF
--- a/src/library/components/assigments/index.js
+++ b/src/library/components/assigments/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ClassAssignments from './class-assignments'
-import { activityMapping, studentMapping } from '../common/offering-progress/helpers'
+import { reportableActivityMapping, studentMapping } from '../common/offering-progress/helpers'
 import OfferingsTable from './offerings-table'
 import { arrayMove } from 'react-sortable-hoc'
 
@@ -44,10 +44,11 @@ const classMapping = data => {
 const offeringDetailsMapping = data => {
   return {
     id: data.id,
+    activityName: data.activity,
     previewUrl: data.activity_url,
     reportUrl: data.report_url,
     externalReport: externalReportMapping(data.external_report),
-    activities: data.activities.map(a => activityMapping(a)),
+    reportableActivities: data.reportable_activities && data.reportable_activities.map(a => reportableActivityMapping(a)),
     students: data.students.map(s => studentMapping(s))
   }
 }

--- a/src/library/components/assigments/offering-details.js
+++ b/src/library/components/assigments/offering-details.js
@@ -6,7 +6,9 @@ import commonCss from '../../styles/common-css-modules.scss'
 
 export default class OfferingDetails extends React.Component {
   render () {
-    const { previewUrl, reportUrl, externalReport, students, activities } = this.props.offering
+    const { activityName, previewUrl, reportUrl, externalReport, students, reportableActivities } = this.props.offering
+    // Activities listed in the progress table are either reportable activities or just the main offering.
+    const progressTableActivities = reportableActivities || [{ id: 0, name: activityName, feedbackOptions: null }]
     return (
       <div className={css.offeringDetails}>
         <a href={previewUrl} target='_blank' className={commonCss.smallButton} title='Preview'>Preview</a>
@@ -19,7 +21,7 @@ export default class OfferingDetails extends React.Component {
           <a href={externalReport.url} target='_blank' className={commonCss.smallButton} title={externalReport.name}>{ externalReport.launchText }</a>
         }
         <div className={css.progressContainer}>
-          <OfferingProgress activities={activities} students={students} />
+          <OfferingProgress activities={progressTableActivities} students={students} />
         </div>
       </div>
     )

--- a/src/library/components/common/offering-progress/helpers.js
+++ b/src/library/components/common/offering-progress/helpers.js
@@ -34,7 +34,7 @@ export const studentMapping = data => ({
   detailedProgress: data.detailed_progress && data.detailed_progress.map(dp => detailedProgressMapping(dp))
 })
 
-export const activityMapping = data => ({
+export const reportableActivityMapping = data => ({
   id: data.id,
   name: data.name,
   reportUrl: data.activity_report_url,

--- a/src/library/components/common/offering-progress/helpers.js
+++ b/src/library/components/common/offering-progress/helpers.js
@@ -29,6 +29,7 @@ export const studentMapping = data => ({
   name: data.last_name + ', ' + data.first_name,
   lastRun: data.last_run && new Date(data.last_run),
   totalProgress: data.total_progress,
+  startedActivity: data.started_activity,
   reportUrl: data.learner_report_url,
   detailedProgress: data.detailed_progress && data.detailed_progress.map(dp => detailedProgressMapping(dp))
 })

--- a/src/library/components/common/offering-progress/index.js
+++ b/src/library/components/common/offering-progress/index.js
@@ -31,7 +31,6 @@ export default class ProgressTable extends React.Component {
   renderStudentProgressBars (student) {
     const { activities } = this.props
     let detailedProgress = []
-
     if (student.detailedProgress) {
       // Detailed progress available. Render it.
       detailedProgress = student.detailedProgress
@@ -80,7 +79,9 @@ export default class ProgressTable extends React.Component {
         <div className={css.progressTableContainer}>
           <table className={css.progressTable}>
             <tbody>
-              <tr>{ activities.map((a, idx) => <th key={idx}>{ this.renderActivityHeader(a) }</th>) }</tr>
+              <tr>
+                { activities.map((a, idx) => <th key={idx}>{ this.renderActivityHeader(a) }</th>) }
+              </tr>
               {
                 students.map(student =>
                   <tr key={student.id}>

--- a/src/library/components/common/offering-progress/index.js
+++ b/src/library/components/common/offering-progress/index.js
@@ -5,7 +5,8 @@ import css from './style.scss'
 
 const formatDate = date => `${date.getMonth() + 1}/${date.getDate()}`
 
-const noProgressForActivities = activities => activities.map(a => ({ activityId: a.id, progress: 0, reportUrl: null }))
+const notLaunchedDetailedProgress = activities => activities.map(a => ({ activityId: a.id, progress: 0, reportUrl: null }))
+const launchedDetailedProgress = activities => activities.map(a => ({ activityId: a.id, progress: 100, info: 'launched', reportUrl: null }))
 
 export default class ProgressTable extends React.Component {
   getFeedbackOptions (activityId) {
@@ -13,8 +14,40 @@ export default class ProgressTable extends React.Component {
     return activities.find(a => a.id === activityId).feedbackOptions
   }
 
+  renderActivityHeader (act) {
+    const name = <span className={css.activityTitle}>{ act.name }</span>
+    return act.reportUrl
+      ? <a href={act.reportUrl} target='_blank' title={`Open report for "${act.name}"`}>{ name }</a>
+      : name
+  }
+
   renderStudentName (student) {
-    return <span className={css.name}>{ student.name }</span>
+    const name = <span className={css.name}>{ student.name }</span>
+    return student.reportUrl && student.totalProgress > 0
+      ? <a href={student.reportUrl} target='_blank' title={`Open report for ${student.name}`}>{ name }</a>
+      : name
+  }
+
+  renderStudentProgressBars (student) {
+    const { activities } = this.props
+    let detailedProgress = []
+
+    if (student.detailedProgress) {
+      // Detailed progress available. Render it.
+      detailedProgress = student.detailedProgress
+    } else if (!student.startedActivity) {
+      // Otherwise, there are two options. Student has run offering or not. In this case we need to render
+      // empty bar or full progress bar with "launched" label.
+      detailedProgress = notLaunchedDetailedProgress(activities)
+    } else if (student.startedActivity) {
+      detailedProgress = launchedDetailedProgress(activities)
+    }
+
+    return detailedProgress.map((details, idx) => (
+      <td key={idx}>
+        <ProgressBar student={student} detailedProgress={details} feedbackOptions={this.getFeedbackOptions(details.activityId)} />
+      </td>
+    ))
   }
 
   render () {
@@ -22,7 +55,6 @@ export default class ProgressTable extends React.Component {
     if (students.length === 0) {
       return null
     }
-    const noProgress = noProgressForActivities(activities)
     return (
       <div className={css.offeringProgress}>
         <div className={css.namesTableContainer}>
@@ -35,13 +67,7 @@ export default class ProgressTable extends React.Component {
               {
                 students.map(student =>
                   <tr key={student.id}>
-                    <td>
-                      {
-                        student.totalProgress > 0
-                          ? <a href={student.reportUrl} target='_blank' title={`Open report for ${student.name}`}>{ this.renderStudentName(student) }</a>
-                          : this.renderStudentName(student)
-                      }
-                    </td>
+                    <td>{ this.renderStudentName(student) }</td>
                     <td className={css.date} title={student.lastRun && student.lastRun.toLocaleDateString()}>
                       { student.lastRun ? formatDate(student.lastRun) : 'n/a' }
                     </td>
@@ -54,24 +80,11 @@ export default class ProgressTable extends React.Component {
         <div className={css.progressTableContainer}>
           <table className={css.progressTable}>
             <tbody>
-              <tr>
-                {
-                  activities.map((a, idx) =>
-                    <th key={idx}><a href={a.reportUrl} target='_blank' title={`Open report for "${a.name}"`}>
-                      <span className={css.activityTitle}>{ a.name }</span></a>
-                    </th>)
-                }
-              </tr>
+              <tr>{ activities.map((a, idx) => <th key={idx}>{ this.renderActivityHeader(a) }</th>) }</tr>
               {
                 students.map(student =>
                   <tr key={student.id}>
-                    {
-                      (student.detailedProgress || noProgress).map((details, idx) =>
-                        <td key={idx}>
-                          <ProgressBar student={student} detailedProgress={details} feedbackOptions={this.getFeedbackOptions(details.activityId)} />
-                        </td>
-                      )
-                    }
+                    { this.renderStudentProgressBars(student) }
                   </tr>
                 )
               }

--- a/src/library/components/common/offering-progress/progress-bar.js
+++ b/src/library/components/common/offering-progress/progress-bar.js
@@ -11,7 +11,7 @@ export default class ProgressBar extends React.Component {
 
   get clickable () {
     const { detailedProgress } = this.props
-    return detailedProgress.progress > 0
+    return detailedProgress.reportUrl && detailedProgress.progress > 0
   }
 
   onClick () {
@@ -30,6 +30,9 @@ export default class ProgressBar extends React.Component {
         <div className={`${css.bar} ${detailedProgress.progress === 100 ? css.completed : ''}`}
           style={{width: `${detailedProgress.progress}%`}} />
         <div className={css.textContainer}>
+          {
+            detailedProgress.info && <span className={css.textInfo}>{ detailedProgress.info }</span>
+          }
           {
             detailedProgress.progress > 0 && feedbackOptions &&
             <Feedback feedback={detailedProgress.feedback} options={feedbackOptions} />

--- a/src/library/components/common/offering-progress/style.scss
+++ b/src/library/components/common/offering-progress/style.scss
@@ -84,6 +84,10 @@
           color: black;
           line-height: 25px;
 
+          .textInfo {
+            margin-left: 5px;
+          }
+
           .reportLink {
             float: right;
             color: #ad5100;

--- a/src/library/components/recent-activity/index.js
+++ b/src/library/components/recent-activity/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Offerings from './offerings'
-import { activityMapping, studentMapping } from '../common/offering-progress/helpers'
+import { reportableActivityMapping, studentMapping } from '../common/offering-progress/helpers'
 
 const externalReportMapping = data => {
   if (!data) {
@@ -23,7 +23,7 @@ const offeringMapping = data => {
   return {
     id: data.id,
     clazz: data.clazz,
-    activity: data.activity,
+    activityName: data.activity,
     previewUrl: data.activity_url,
     lastRun: lastRunDates.length > 0 ? lastRunDates[0] : null,
     notStartedStudentsCount: notStartedStudents.length,
@@ -31,7 +31,7 @@ const offeringMapping = data => {
     completedStudentsCount: completedStudents.length,
     reportUrl: data.report_url,
     externalReport: externalReportMapping(data.external_report),
-    activities: data.activities.map(a => activityMapping(a)),
+    reportableActivities: data.reportable_activities && data.reportable_activities.map(a => reportableActivityMapping(a)),
     students: data.students.map(s => studentMapping(s))
   }
 }

--- a/src/library/components/recent-activity/index.js
+++ b/src/library/components/recent-activity/index.js
@@ -17,9 +17,12 @@ const offeringMapping = data => {
     // Filer out offerings that have never been run.
     .filter(s => s.last_run !== null)
     .map(s => new Date(s.last_run))
-  const notStartedStudents = data.students.filter(s => s.total_progress === 0)
-  const inProgressStudents = data.students.filter(s => s.total_progress > 0 && s.total_progress < 100)
-  const completedStudents = data.students.filter(s => s.total_progress === 100)
+  // Reportable offerings will have meaningful progress specified. Non-reportable offerings will have some progress
+  // specified too (99% or 100%), but it's safer to look at started_activity property.
+  const reportable = data.reportable
+  const notStartedStudents = data.students.filter(s => reportable ? s.total_progress === 0 : !s.started_activity)
+  const inProgressStudents = data.students.filter(s => reportable ? s.total_progress > 0 && s.total_progress < 100 : false)
+  const completedStudents = data.students.filter(s => reportable ? s.total_progress === 100 : s.started_activity)
   return {
     id: data.id,
     clazz: data.clazz,

--- a/src/library/components/recent-activity/offering.js
+++ b/src/library/components/recent-activity/offering.js
@@ -25,15 +25,17 @@ export default class Offering extends React.Component {
 
   render () {
     const { detailsVisible } = this.state
-    const { clazz, activity, previewUrl, students, activities, reportUrl, externalReport,
+    const { clazz, activityName, previewUrl, students, reportableActivities, reportUrl, externalReport,
       completedStudentsCount, inProgressStudentsCount, notStartedStudentsCount } = this.props.offering
     const completedWidth = (completedStudentsCount / students.length) * 100
     const inProgressWidth = (inProgressStudentsCount / students.length) * 100
     const notStartedWidth = (notStartedStudentsCount / students.length) * 100
+    // Activities listed in the progress table are either reportable activities or just the main offering.
+    const progressTableActivities = reportableActivities || [{ id: 0, name: activityName, feedbackOptions: null }]
     return (
       <div className={css.offering}>
         <div>
-          <span className={css.offeringHeader}>{clazz}: {activity}</span>
+          <span className={css.offeringHeader}>{clazz}: { activityName }</span>
           <a className={css.detailsToggle} onClick={this.toggleDetails}>{this.detailsToggleLabel}</a>
         </div>
         <div>
@@ -62,7 +64,7 @@ export default class Offering extends React.Component {
           }
         </div>
         <div>
-          { detailsVisible && <OfferingProgress activities={activities} students={students} /> }
+          { detailsVisible && <OfferingProgress activities={progressTableActivities} students={students} /> }
         </div>
       </div>
     )


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/736901/stories/157700766

Mostly related to changes in Portal API: https://github.com/concord-consortium/rigse/pull/496
Gererally it implements correct support of non-LARA external activities.

Non-reportable external activities will have "launched" text in the bar (@ddamelin suggested that and it was easy to add):

<img width="721" alt="screen shot 2018-05-18 at 15 14 42" src="https://user-images.githubusercontent.com/767857/40260316-d0488b36-5aae-11e8-8f38-83b66116569f.png">

Nothing is clicable there, as there are no reports available. You can see that progress bar is dark orange as this code doesn't care about progress (whether it's 99% or 100%) but whether activity has been started or not. (Actually, Student1 has progress 99% as the activity was launched before Portal change, and Student2 has progress 100% as the activity was launched after Portal update.)