### PR TITLE
Fix: `z-index` of navigation overlay.

### DIFF
--- a/src/library/components/navigation/style.scss
+++ b/src/library/components/navigation/style.scss
@@ -1,7 +1,7 @@
 .leftNavigation {
   &.overlay {
     position: absolute;
-    z-index: 100;
+    z-index: 1;
     .head {
       border-right: 1px solid white;
     }


### PR DESCRIPTION
Simple fix to problem with the navigation obscuring activity editing in the portal.

Note:  There was a similar fix in Portal where the pop-up overlay z-index had to be explicitly set, so that the overlay z-index was > 1.

@scytacki please have a quick look.  