### PR TITLE
Tweaks to clean up unit-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /temp
 /dest
 /dest-portals
+/coverage
 node_modules
 npm-debug.log
 \.DS_Store

--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ Although the most desirable developer experience is one where we start by writin
 This example can be demonstrated by using the techniques previously described in this document. It goes something like this:
 
 * Refresh the dependencies. Typically done with `npm install`.
-* Serve example page: `npm run start`
-* Navigating a browser to the unit-testing-example's html page. `localhost:8080/examples/unit-test-example.html`. Note: if you already have a server running on 8080, a random port will be chosen. The base URL is added to the clipboard so you can paste it into your browser.
+* Build and serve up the example page: `npm run start`
+* Navigating a browser to the unit-testing-example's html page.
 
-At this point you should see a boring little html page with some descriptive text. But most important, is a small display at the bottom of the page,
+  Use `localhost:8080/examples/unit-test-example.html`. Note: if you already have a server running on 8080, a random port will be chosen. The base URL is added to the clipboard so you can paste it into your browser.
+
+At this point you should see a boring little html page with some descriptive text. But most important, there is a small display at the bottom of the page,
 
 ```
 The Meaning of Life:"42"
@@ -140,16 +142,18 @@ The Meaning of Life:"42"
 
 This display is coming from our React component that is under test, `DisplayText`.
 
-To run the unit tests, use the command `npm test`, which will run all the tests and start a file watcher. As files change, the tests will be re-run for you. The display should looks something like this:
+To run the unit tests, use the command `npm test`, which will run all the tests and start a file watcher. As files change, the tests will be re-run for you. The display should look something like this:
 
 ```
- PASS  tests/library/components/unit-test-example/display-text.test.js  When I try to display some text
-    ✓ shows what I asked for in the body (3ms)
+ PASS  tests/library/components/unit-test-example/display-text.test.js
+   When I try to display some text
+    ✓ shows what I asked for in the label (3ms)
     ✓ shows what I asked for as the value
 
 Test Suites: 1 passed, 1 total
-Tests:       2 passed, 2 totalSnapshots:   0 total
-Time:        7.237s
+Tests:       2 passed, 2 total
+Snapshots:   0 total
+Time:        1.098s
 Ran all test suites related to changed files.
 
 Watch Usage: Press w to show more.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
       "OfferingRunStatus"
     ]
   },
+  "jest": {
+    "modulePaths": [ "src/library" ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concord-consortium/portal-pages.git"

--- a/tests/library/components/unit-test-example/display-text.test.js
+++ b/tests/library/components/unit-test-example/display-text.test.js
@@ -1,8 +1,7 @@
-import React from 'react';
-import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
-import DisplayText from
-  '../../../../src/library/components/unit-test-example/display-text'
+import React from 'react'
+import Enzyme from 'enzyme'
+import Adapter from 'enzyme-adapter-react-15'
+import DisplayText from 'components/unit-test-example/display-text'
 
 Enzyme.configure( { adapter: new Adapter() });
 
@@ -10,7 +9,7 @@ describe('When I try to display some text', () => {
   const label = "this is a label";
   const value = "this is a value";
   const display_text = Enzyme.mount(<DisplayText label={label} value={value} />);
-  it ('shows what I asked for in the body', () => {
+  it ('shows what I asked for in the label', () => {
     expect(display_text.prop('value')).toBe(value);
   });
   it ('shows what I asked for as the value', () => {


### PR DESCRIPTION
- Added /coverage to .gitignore in prep for Jest coverage experiments.
- Typos and such to README.
- Added module search paths to package.json for unit-test files.
- Uncluttered path of imports in test file.