### PR TITLE
Fixed external report button disable [#166800316]

### DIFF
--- a/src/library/components/common/external-report-button.js
+++ b/src/library/components/common/external-report-button.js
@@ -21,24 +21,16 @@ const postToUrl = (url, json, signature, portalToken) => {
 export default class ExternalReportButton extends React.Component {
   constructor (props) {
     super(props)
-    this.state = {
-      disabled: props.isDisabled()
-    }
     this.handleClick = this.handleClick.bind(this)
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.setState({ disabled: this.isDisabled() })
-  }
-
   render () {
-    const { label } = this.props
-    const { disabled } = this.state
-    return <input style={{ marginRight: 10 }} type='submit' onClick={this.handleClick} disabled={disabled} value={label} />
+    const { label, isDisabled } = this.props
+    return <input style={{ marginRight: 10 }} type='submit' onClick={this.handleClick} disabled={isDisabled} value={label} />
   }
 
   handleClick (event) {
-    const { reportUrl, queryUrl, getQueryParams, postToUrl, portalToken } = this.props
+    const { reportUrl, queryUrl, queryParams, postToUrl, portalToken } = this.props
     // Make sure we don't submit a form if this component is part of a form (it's possible but not required).
     event.preventDefault()
     // Get the signed query JSON first.
@@ -46,7 +38,7 @@ export default class ExternalReportButton extends React.Component {
       type: 'GET',
       dataType: 'json',
       // jQuery.param nicely converts JS hash into query params string.
-      url: `${queryUrl}?${jQuery.param(getQueryParams())}`,
+      url: `${queryUrl}?${jQuery.param(queryParams)}`,
       success: response => {
         postToUrl(reportUrl, response.json, response.signature, portalToken)
       },

--- a/src/library/components/learner-report-form/index.js
+++ b/src/library/components/learner-report-form/index.js
@@ -35,9 +35,10 @@ export default class LearnerReportForm extends React.Component {
       waitingFor_schools: false,
       waitingFor_teachers: false,
       waitingFor_runnables: false,
-      waitingFor_permission_forms: false
+      waitingFor_permission_forms: false,
+      externalReportButtonDisabled: true,
+      queryParams: {}
     }
-    this.getQueryParams = this.getQueryParams.bind(this)
   }
 
   componentWillMount () {
@@ -141,8 +142,10 @@ export default class LearnerReportForm extends React.Component {
     return params
   }
 
-  isExternalReportDisabled () {
-    return Object.keys(this.getQueryParams()).length === 0
+  updateQueryParams () {
+    const queryParams = this.getQueryParams()
+    const externalReportButtonDisabled = Object.keys(queryParams).length === 0
+    this.setState({ queryParams, externalReportButtonDisabled })
   }
 
   updateFilters () {
@@ -205,6 +208,7 @@ export default class LearnerReportForm extends React.Component {
     const handleSelectChange = value => {
       this.setState({ [name]: value }, () => {
         this.updateFilters()
+        this.updateQueryParams()
       })
     }
 
@@ -236,6 +240,7 @@ export default class LearnerReportForm extends React.Component {
       }
       this.setState({ [name]: formatDate(value) }, () => {
         this.updateFilters()
+        this.updateQueryParams()
       })
     }
 
@@ -284,6 +289,7 @@ export default class LearnerReportForm extends React.Component {
 
   renderForm () {
     const { externalReports } = this.props
+    const { queryParams, externalReportButtonDisabled } = this.state
     // ...LEARNER_QUERY is the renamed ...REPORT_QUERY, use a fallback to wait for the portal to update
     const queryUrl = Portal.API_V1.EXTERNAL_RESEARCHER_REPORT_LEARNER_QUERY || Portal.API_V1.EXTERNAL_RESEARCHER_REPORT_QUERY
 
@@ -304,7 +310,7 @@ export default class LearnerReportForm extends React.Component {
         {this.renderButton('Arg Block Report')}
 
         {externalReports.map(lr =>
-          <ExternalReportButton key={lr.url + lr.label} label={lr.label} reportUrl={lr.url} queryUrl={queryUrl} isDisabled={this.isExternalReportDisabled} getQueryParams={this.getQueryParams} />
+          <ExternalReportButton key={lr.url + lr.label} label={lr.label} reportUrl={lr.url} queryUrl={queryUrl} isDisabled={externalReportButtonDisabled} queryParams={queryParams} />
         )}
       </form>
     )

--- a/src/library/components/user-report-form/index.js
+++ b/src/library/components/user-report-form/index.js
@@ -33,9 +33,10 @@ export default class UserReportForm extends React.Component {
       waitingFor_runnables: false,
       totals: {},
       // checkbox options
-      removeCCTeachers: false
+      removeCCTeachers: false,
+      externalReportButtonDisabled: true,
+      queryParams: {}
     }
-    this.getQueryParams = this.getQueryParams.bind(this)
   }
 
   componentWillMount () {
@@ -123,9 +124,11 @@ export default class UserReportForm extends React.Component {
     return params
   }
 
-  isExternalReportDisabled () {
+  updateQueryParams () {
+    const queryParams = this.getQueryParams()
     // <= 1 is used because the params always has remove_cc_teachers defined
-    return Object.keys(this.getQueryParams()).length <= 1
+    const externalReportButtonDisabled = Object.keys(queryParams).length <= 1
+    this.setState({ queryParams, externalReportButtonDisabled })
   }
 
   updateFilters () {
@@ -158,6 +161,7 @@ export default class UserReportForm extends React.Component {
     const handleSelectChange = value => {
       this.setState({ [name]: value }, () => {
         this.updateFilters()
+        this.updateQueryParams()
       })
     }
 
@@ -198,7 +202,9 @@ export default class UserReportForm extends React.Component {
         // Incorrect date.
         return
       }
-      this.setState({ [name]: formatDate(value) })
+      this.setState({ [name]: formatDate(value) }, () => {
+        this.updateQueryParams()
+      })
     }
 
     return (
@@ -219,6 +225,7 @@ export default class UserReportForm extends React.Component {
 
   renderForm () {
     const { externalReports, portalToken } = this.props
+    const { queryParams, externalReportButtonDisabled } = this.state
     const queryUrl = Portal.API_V1.EXTERNAL_RESEARCHER_REPORT_USER_QUERY
 
     const handleRemoveCCTeachers = e => {
@@ -242,7 +249,7 @@ export default class UserReportForm extends React.Component {
 
         <div style={{ marginTop: '12px' }}>
           {externalReports.map(lr =>
-            <ExternalReportButton key={lr.url + lr.label} label={lr.label} reportUrl={lr.url} queryUrl={queryUrl} isDisabled={this.isExternalReportDisabled} getQueryParams={this.getQueryParams} portalToken={portalToken} />
+            <ExternalReportButton key={lr.url + lr.label} label={lr.label} reportUrl={lr.url} queryUrl={queryUrl} isDisabled={externalReportButtonDisabled} queryParams={queryParams} portalToken={portalToken} />
           )}
         </div>
 

--- a/tests/library/components/common/external-report-button.test.js
+++ b/tests/library/components/common/external-report-button.test.js
@@ -8,8 +8,8 @@ import nock from 'nock'
 Enzyme.configure({adapter: new Adapter()})
 
 describe('ExternalReportButton', () => {
-  const getQueryParams = () => ({ teachers: 1, otherParam: 'abc' })
-  const isDisabled = () => false
+  const queryParams = { teachers: 1, otherParam: 'abc' }
+  const isDisabled = false
   const postToUrlMock = jest.fn()
   const queryUrl = 'http://query-test.concord.org'
   const queryJson = {fakeQueryJson: true}
@@ -18,7 +18,7 @@ describe('ExternalReportButton', () => {
   const reportUrl = 'http://log-puller-test.concord.org'
 
   const wrapper = Enzyme.shallow(
-    <ExternalReportButton label='test label' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} getQueryParams={getQueryParams} postToUrl={postToUrlMock} />
+    <ExternalReportButton label='test label' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} queryParams={queryParams} postToUrl={postToUrlMock} />
   )
 
   it('displays the label', () => {
@@ -30,10 +30,10 @@ describe('ExternalReportButton', () => {
   })
 
   describe('when there are no query params', () => {
-    const getQueryParams = () => ({})
-    const isDisabled = () => true
+    const queryParams = {}
+    const isDisabled = true
     const wrapper = Enzyme.shallow(
-      <ExternalReportButton label='test disabled' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} getQueryParams={getQueryParams} postToUrl={postToUrlMock} />
+      <ExternalReportButton label='test disabled' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} queryParams={queryParams} postToUrl={postToUrlMock} />
     )
 
     it('disables the button', () => {
@@ -46,12 +46,12 @@ describe('ExternalReportButton', () => {
       const logsQueryRequest = nock(queryUrl)
         .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
         .get('/')
-        .query(getQueryParams())
+        .query(queryParams)
         .reply(200, {json: queryJson, signature: querySignature})
 
       const postToUrlMock = jest.fn()
       const wrapper = Enzyme.shallow(
-        <ExternalReportButton label='test label' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} getQueryParams={getQueryParams} postToUrl={postToUrlMock} />
+        <ExternalReportButton label='test label' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} queryParams={queryParams} postToUrl={postToUrlMock} />
       )
 
       const eventMock = { preventDefault: jest.fn() }
@@ -73,13 +73,13 @@ describe('ExternalReportButton', () => {
       const postToUrlMock = jest.fn()
       const portalToken = "testtoken"
       const wrapper = Enzyme.shallow(
-        <ExternalReportButton label='test label' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} getQueryParams={getQueryParams} postToUrl={postToUrlMock} portalToken={portalToken} />
+        <ExternalReportButton label='test label' reportUrl={reportUrl} queryUrl={queryUrl} isDisabled={isDisabled} queryParams={queryParams} postToUrl={postToUrlMock} portalToken={portalToken} />
       )
 
       const logsQueryRequest = nock(queryUrl)
         .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
         .get('/')
-        .query(getQueryParams())
+        .query(queryParams)
         .reply(200, {json: queryJson, signature: querySignature, portalToken})
 
       const eventMock = { preventDefault: jest.fn() }


### PR DESCRIPTION
Unlike the previous fix this fix updates the outer report form state, ensuring that the report button is re-rendered with each change to the form input.