### PR TITLE
Add multiple external reports to assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Concord Portal Pages
 
-This respository serves multiple purposes:
+This repository serves multiple purposes:
 
 1. It contains the code for portal-pages.js which is a library of React components used by the Portal.
 1. It allows for version control for the various custom portal page content areas like the homepage and project or collection pages.
@@ -110,7 +110,7 @@ https://portal-pages.concord.org/<branch|version>/<branch-or-tag>/library/portal
 
 ## Building an example page for a new Portal React Component ##
 
-Create an HTML file in `src/examples/`.  It will be easiest to copy one of the existing examples. You also need to a new line to webpack.config.js: look for the lines that look like `example(...)`, and add a new one for your example.  
+Create an HTML file in `src/examples/`.  It will be easiest to copy one of the existing examples. You also need to add a new line to webpack.config.js: look for the lines that look like `example(...)`, and add a new one for your example.  
 
 `npm run start` and `npm run start:prod` can both be used to view these examples locally.  `npm run build` will build them and put the result in `dest/examples`.  When you push a branch the examples will be built by travis and deployed to  `https://portal-pages.concord.org/<branch|version>/<branch-or-tag>/examples/<your-example>.html`.
 

--- a/src/examples/assignments.html
+++ b/src/examples/assignments.html
@@ -2,8 +2,8 @@
 	<head>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.2/prop-types.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/react-select/1.2.0/react-select.js"></script>
+			<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.2/prop-types.js"></script>
+			<script src="https://cdnjs.cloudflare.com/ajax/libs/react-select/1.2.0/react-select.js"></script>
 			<script src="https://code.jquery.com/jquery-1.8.2.js"></script>
 			<script src="./portal-api.js"></script>
 	</head>

--- a/src/examples/assignments.html
+++ b/src/examples/assignments.html
@@ -2,6 +2,8 @@
 	<head>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.2/prop-types.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/react-select/1.2.0/react-select.js"></script>
 			<script src="https://code.jquery.com/jquery-1.8.2.js"></script>
 			<script src="./portal-api.js"></script>
 	</head>
@@ -42,7 +44,7 @@
             'name': 'Test sequence',
             'active': true,
             'locked': false,
-            'url': 'http://app.rigse.docker/api/v1/offerings/4'
+            'url': 'mock-data/offering-4.json'
           }, {
             'id': 2,
             'name': 'Test activity 1',

--- a/src/examples/mock-data/offering-4.json
+++ b/src/examples/mock-data/offering-4.json
@@ -1,0 +1,117 @@
+{
+  "NOTES": "This is some random saved json from a learn.staging offering.",
+  "NOTES2": "It is good enough to make the first assignment in the assignments example work",
+  "id": 1164,
+  "teacher": "Scott Cytacki",
+  "clazz": "Demo 4",
+  "clazz_id": 185,
+  "clazz_info_url": "mock-data/class-185.json",
+  "activity": "Reporting Representation Demo",
+  "activity_url": "https://authoring.staging.concord.org/activities/20128",
+  "material_type": "Activity",
+  "report_url": "https://learn.staging.concord.org/portal/offerings/1164/report",
+  "preview_url": "https://learn.staging.concord.org/eresources/1223.run_resource_html?logging=true",
+  "external_report": {
+    "id": 27,
+    "name": "Firestore Report",
+    "url": "https://learn.staging.concord.org/portal/offerings/1164/external_report/27",
+    "launch_text": "Firestore Report"
+  },
+  "external_reports": [
+    {
+      "id": 27,
+      "name": "Firestore Report",
+      "url": "https://learn.staging.concord.org/portal/offerings/1164/external_report/27",
+      "launch_text": "Firestore Report"
+    },
+    {
+      "id": 28,
+      "name": "GEODE Dashboard",
+      "url": "https://learn.staging.concord.org/portal/offerings/1164/external_report/28",
+      "launch_text": "GEODE Dashboard"
+    }
+  ],
+  "reportable": true,
+  "reportable_activities": [
+    {
+      "id": 1314,
+      "name": "Reporting Representation Demo",
+      "type": "Activity",
+      "activity_report_url": "https://learn.staging.concord.org/portal/offerings/1164/activity/1314",
+      "feedback_options": {
+        "score_feedback_enabled": false,
+        "text_feedback_enabled": false,
+        "rubric_feedback_enabled": false,
+        "score_type": "none",
+        "max_score": 10,
+        "rubric_url": "",
+        "rubric": null
+      }
+    }
+  ],
+  "students": [
+    {
+      "name": "Scott Cytacki",
+      "first_name": "Scott",
+      "last_name": "Cytacki",
+      "username": "scytacki1",
+      "user_id": 139,
+      "started_activity": true,
+      "endpoint_url": "https://learn.staging.concord.org/dataservice/external_activity_data/e405f856-abee-4e4e-b974-050d23e199fc",
+      "learner_report_url": "https://learn.staging.concord.org/portal/learners/1465/report",
+      "last_run": "2019-05-13T16:22:36Z",
+      "total_progress": 91.6667,
+      "detailed_progress": [
+        {
+          "activity_id": 1314,
+          "activity_name": "Reporting Representation Demo",
+          "progress": 91.6667,
+          "learner_activity_report_url": "https://learn.staging.concord.org/portal/learners/1465/activity/1314",
+          "feedback": null
+        }
+      ]
+    },
+    {
+      "name": "Scott Cytacki",
+      "first_name": "Scott",
+      "last_name": "Cytacki",
+      "username": "scytacki2",
+      "user_id": 140,
+      "started_activity": true,
+      "endpoint_url": "https://learn.staging.concord.org/dataservice/external_activity_data/9a3591df-2ff9-484b-b91a-25be2116789b",
+      "learner_report_url": "https://learn.staging.concord.org/portal/learners/1466/report",
+      "last_run": "2019-05-13T16:21:40Z",
+      "total_progress": 25,
+      "detailed_progress": [
+        {
+          "activity_id": 1314,
+          "activity_name": "Reporting Representation Demo",
+          "progress": 25,
+          "learner_activity_report_url": "https://learn.staging.concord.org/portal/learners/1466/activity/1314",
+          "feedback": null
+        }
+      ]
+    },
+    {
+      "name": "Scott Student",
+      "first_name": "Scott",
+      "last_name": "Student",
+      "username": "sstudent13",
+      "user_id": 495,
+      "started_activity": true,
+      "endpoint_url": "https://learn.staging.concord.org/dataservice/external_activity_data/799dbac3-9039-486c-b39b-8b86e4fc87de",
+      "learner_report_url": "https://learn.staging.concord.org/portal/learners/1467/report",
+      "last_run": "2019-05-13T16:21:35Z",
+      "total_progress": 33.3333,
+      "detailed_progress": [
+        {
+          "activity_id": 1314,
+          "activity_name": "Reporting Representation Demo",
+          "progress": 33.3333,
+          "learner_activity_report_url": "https://learn.staging.concord.org/portal/learners/1467/activity/1314",
+          "feedback": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/examples/recent-activity.html
+++ b/src/examples/recent-activity.html
@@ -2,6 +2,8 @@
 	<head>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
+			<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.2/prop-types.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/react-select/1.2.0/react-select.js"></script>
 			<script src="https://code.jquery.com/jquery-1.8.2.js"></script>
 			<script src="./portal-api.js"></script>
 	</head>

--- a/src/examples/recent-activity.html
+++ b/src/examples/recent-activity.html
@@ -3,7 +3,7 @@
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.2/prop-types.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/react-select/1.2.0/react-select.js"></script>
+			<script src="https://cdnjs.cloudflare.com/ajax/libs/react-select/1.2.0/react-select.js"></script>
 			<script src="https://code.jquery.com/jquery-1.8.2.js"></script>
 			<script src="./portal-api.js"></script>
 	</head>

--- a/src/library/components/assigments/index.js
+++ b/src/library/components/assigments/index.js
@@ -48,7 +48,7 @@ const offeringDetailsMapping = data => {
     activityName: data.activity,
     previewUrl: data.preview_url,
     reportUrl: data.report_url,
-    externalReport: externalReportMapping(data.external_report),
+    externalReports: data.external_reports && data.external_reports.map(r => externalReportMapping(r)),
     reportableActivities: data.reportable_activities && data.reportable_activities.map(a => reportableActivityMapping(a)),
     students: data.students.map(s => studentMapping(s)).sort(sortByName)
   }

--- a/src/library/components/assigments/offering-details.js
+++ b/src/library/components/assigments/offering-details.js
@@ -6,7 +6,7 @@ import commonCss from '../../styles/common-css-modules.scss'
 
 export default class OfferingDetails extends React.Component {
   render () {
-    const { activityName, previewUrl, reportUrl, externalReport, students, reportableActivities } = this.props.offering
+    const { activityName, previewUrl, reportUrl, externalReports, students, reportableActivities } = this.props.offering
     // Activities listed in the progress table are either reportable activities or just the main offering.
     const progressTableActivities = reportableActivities || [{ id: 0, name: activityName, feedbackOptions: null }]
     return (
@@ -17,8 +17,16 @@ export default class OfferingDetails extends React.Component {
           <a href={reportUrl} target='_blank' className={commonCss.smallButton} title='Report'>Report</a>
         }
         {
-          externalReport &&
-          <a href={externalReport.url} target='_blank' className={commonCss.smallButton} title={externalReport.name}>{ externalReport.launchText }</a>
+          externalReports && externalReports.map((externalReport, index) => {
+            return (
+              <a href={externalReport.url}
+                key={index}
+                target='_blank'
+                className={commonCss.smallButton}>
+                { externalReport.launchText }
+              </a>
+            )
+          })
         }
         <div className={css.progressContainer}>
           <OfferingProgress activities={progressTableActivities} students={students} />


### PR DESCRIPTION
this copies code from the multiple external report support in the recent activity components

this also updates the examples so this support can be manually tested without connecting to a real portal