### PR TITLE
handle a null education_level

### DIFF
--- a/src/library/helpers/standards-helpers.js
+++ b/src/library/helpers/standards-helpers.js
@@ -249,6 +249,11 @@ var NgssHelper = function () {
   // notation string for a DCI.
   //
   this.getGradeLevel = function (gradeArray) {
+    // some gradeArrays have been null
+    if (!gradeArray) {
+      return 'UNKNOWN'
+    }
+
     //
     // For single grade level return single grade.
     //


### PR DESCRIPTION
I'm not sure if a null education_level is a valid state for the standards.
But there are some standards selected on learn.staging that have null education_levels