### PR TITLE
Fixed single quotes in report data values [#168144441]

### DIFF
--- a/src/library/components/common/external-report-button.js
+++ b/src/library/components/common/external-report-button.js
@@ -1,17 +1,24 @@
 import React from 'react'
 import jQuery from 'jquery'
 
+// changed from string based form generation to using jQuery to fix issue with single quoted
+// values in json field (it was delimited with single quotes and would break if the json
+// contained values with single quotes)
+export const generateJQueryForm = (url, json, signature, portalToken) => {
+  const form = jQuery('<form>', { action: url, method: 'POST' })
+    .append(jQuery('<input>', { type: 'hidden', name: 'allowDebug', value: '1' }))
+    .append(jQuery('<input>', { type: 'hidden', name: 'json', value: JSON.stringify(json) }))
+    .append(jQuery('<input>', { type: 'hidden', name: 'signature', value: signature }))
+  if (portalToken) {
+    form.append(jQuery('<input>', { type: 'hidden', name: 'portal_token', value: portalToken }))
+  }
+  return form
+}
+
 const postToUrl = (url, json, signature, portalToken) => {
   // Issue POST request to Log app. We can't use GET, as URL could get too long. Generating a fake
   // form is a way to send non-Ajax POST request and open the target page.
-  const tempForm = jQuery(
-    `<form action="${url}" method="POST">` +
-    `<input type="hidden" name="allowDebug" value="1">` +
-    `<input type="hidden" name="json" value='${JSON.stringify(json)}'>` +
-    `<input type="hidden" name="signature" value="${signature}">` +
-    (portalToken ? `<input type="hidden" name="portal_token" value="${portalToken}">` : '') +
-    `</form>`
-  )
+  const tempForm = generateJQueryForm(url, json, signature, portalToken)
   tempForm.appendTo('body').submit()
   // Unless form uses target="_blank", this action results in redirect and cleanup is not necessary.
   // But it won't hurt and if target="_blank" is ever used, it's gonna be useful.

--- a/tests/library/components/common/external-report-button.test.js
+++ b/tests/library/components/common/external-report-button.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-15'
 import ExternalReportButton from 'components/common/external-report-button'
+import {generateJQueryForm} from 'components/common/external-report-button'
 import nock from 'nock'
 
 Enzyme.configure({adapter: new Adapter()})
@@ -95,6 +96,15 @@ describe('ExternalReportButton', () => {
         expect(postToUrlMock).toBeCalledWith(reportUrl, queryJson, querySignature, portalToken)
         done()
       }, 100)
+    })
+  })
+
+  describe('when the query contains a value that includes a single quote', () => {
+    it('escapes the generated form correctly', () => {
+      const json = {query: "What's up doc?"}
+      const portalToken = "testtoken"
+      const form = generateJQueryForm(reportUrl, json, querySignature, portalToken);
+      expect(form.html()).toBe("<input type=\"hidden\" name=\"allowDebug\" value=\"1\"><input type=\"hidden\" name=\"json\" value=\"{&quot;query&quot;:&quot;What's up doc?&quot;}\"><input type=\"hidden\" name=\"signature\" value=\"fakeQueryHMACSignature\"><input type=\"hidden\" name=\"portal_token\" value=\"testtoken\">");
     })
   })
 })


### PR DESCRIPTION
We were building the form that was sent to the portal to generate the external report url using strings but that broken with values that contained single quotes.  Now we are using jQuery to generate the form so we don't need to worry about manually escaping it.