### PR TITLE
fix date filters on researcher report

### DIFF
--- a/src/library/components/learner-report-form/index.js
+++ b/src/library/components/learner-report-form/index.js
@@ -248,7 +248,7 @@ export default class LearnerReportForm extends React.Component {
       <div>
         <div>{label}</div>
         <DayPickerInput
-          name={name}
+          inputProps={{ name: name }}
           placeholder={'MM/DD/YYYY'}
           format={'MM/DD/YYYY'}
           parseDate={parseDate}

--- a/src/library/components/user-report-form/index.js
+++ b/src/library/components/user-report-form/index.js
@@ -211,7 +211,7 @@ export default class UserReportForm extends React.Component {
       <div style={{ marginTop: '6px' }}>
         <div>{label}</div>
         <DayPickerInput
-          name={name}
+          inputProps={{ name: name }}
           placeholder={'MM/DD/YYYY'}
           format={'MM/DD/YYYY'}
           parseDate={parseDate}


### PR DESCRIPTION
The name property of the input element was not set without this change.
The usage and details report buttons do basic browser form submits.
So without the name property the browser will not send this field to
the server. The statistics at the top of the page were working properly
because they are based on a React state instead of the actual
input element in the DOM.

More info about this `inputProps` property:
https://react-day-picker.js.org/api/DayPickerInput/#inputProps

I also updated the name property on the user report form. Technically this isn't necessary, but it seems better to keep these two forms in sync. Alternatively the name property could be removed from this usage of DayPickerInput.

[#170675007]