### PR TITLE
Fix incorrect include when rendering materials-bins [#172782870]

### DIFF
--- a/src/library/components/materials-bin/collections.js
+++ b/src/library/components/materials-bin/collections.js
@@ -14,7 +14,7 @@ class _MBCollections extends React.Component {
 
   render () {
     const className = `mb-cell ${this.getVisibilityClass()}`
-    const {collections} = this.props
+    const { collections } = this.props
     return (
       <div className={className}>
         {this.props.collectionsData != null

--- a/src/library/components/materials-bin/collections.js
+++ b/src/library/components/materials-bin/collections.js
@@ -14,6 +14,7 @@ class _MBCollections extends React.Component {
 
   render () {
     const className = `mb-cell ${this.getVisibilityClass()}`
+    const {collections} = this.props
     return (
       <div className={className}>
         {this.props.collectionsData != null
@@ -24,7 +25,7 @@ class _MBCollections extends React.Component {
               materials={collection.materials}
               archive={this.archive}
               // Merge extra properties that can be provided in collections array.
-              teacherGuideUrl={this.props.collections[idx].teacherGuideUrl}
+              teacherGuideUrl={collections && collections[idx] ? collections[idx].teacherGuideUrl : undefined}
               assignToSpecificClass={this.props.assignToSpecificClass}
             />)
           : <div>Loading...</div>}

--- a/src/library/components/materials-bin/materials-bin.js
+++ b/src/library/components/materials-bin/materials-bin.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import MBMaterialsCategory from './materials-category'
-import MBCollections from './materials-collection'
+import MBCollections from './collections'
 import MBOwnMaterials from './own-materials'
 import MBMaterialsByAuthor from './materials-by-author'
 

--- a/tests/library/components/materials-bin/materials-bin.test.js
+++ b/tests/library/components/materials-bin/materials-bin.test.js
@@ -17,7 +17,7 @@ var materials = [
         children: [
           {
             collections: [
-              {id: "Collection 2"}
+              {id: 1}
              ]
           }
         ]
@@ -36,7 +36,7 @@ var materials = [
         children: [
           {
             collections: [
-              {id: "Collection 3"}
+              {id: 2}
              ]
           }
         ]
@@ -63,7 +63,21 @@ var materials = [
         materialsByAuthor: true
       }
     ]
-  }
+  },
+  {
+    category: "Cat E",
+    children: [
+      {
+        collections: [
+          {
+            id: 1,
+            teacherGuideUrl: 'https://guides.itsi.concord.org/energy-production-teacher-guide.html'
+          }
+        ]
+      }
+    ]
+  },
+
 ];
 
 global.Portal = {
@@ -75,10 +89,23 @@ global.Portal = {
   }
 };
 
+const collectionsResult = [
+  {
+    "name":"Collection",
+    "materials":[
+      {"id":21,"name":"Solar Oven","long_description_for_current_user":"Design, build, and test a solar oven.","long_description":"Design, build, and test a solar oven.","long_description_for_teacher":"","short_description":"Design, build, and test a solar oven.","class_name":"ExternalActivity","class_name_underscored":"external_activity","icon":{"url":"https://learn-resources.concord.org/images/stem-resources/icons/solar-oven.jpg"},"material_properties":[],"is_official":true,"is_archived":false,"is_favorite":false,"favorite_id":null,"subject_areas":["Engineering"],"grade_levels":["3","4"],"projects":[],"publication_status":"published","links":{"browse":{"url":"https://itsi.portal.concord.org/browse/eresources/21"},"preview":{"url":"https://itsi.portal.concord.org/eresources/21.run_resource_html","text":"Preview","target":"_blank"},"print_url":{"text":"Print","target":"_blank","url":"https://authoring.concord.org/activities/988/print_blank"}},"preview_url":"https://itsi.portal.concord.org/eresources/21.run_resource_html","edit_url":null,"unarchive_url":null,"archive_url":null,"copy_url":null,"assign_to_class_url":null,"assign_to_collection_url":null,"assigned_classes":[],"class_count":37,"sensors":[],"has_activities":false,"has_pretest":false,"saves_student_data":true,"activities":[],"lara_activity_or_sequence":true,"parent":null,"user":{"id":32,"name":"ITSI ITEST"},"assigned":false,"credits":null,"license_info":{"name":"Modifications YES, commercial use YES, sharing required  NO (CC-BY-4.0)","code":"CC-BY 4.0","deed":"http://creativecommons.org/licenses/by/4.0/","legal":"http://creativecommons.org/licenses/by/4.0/legalcode","image":"http://i.creativecommons.org/l/by/4.0/88x31.png","description":"This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.","number":1},"related_materials":[],"standard_statements":[],"enable_sharing":true,"slug":"solar-oven","stem_resource_url":"https://itsi.portal.concord.org/resources/21/solar-oven"},
+      {"id":22,"name":"Wind Generator","long_description_for_current_user":"Build a wind turbine and test different blade designs to generate electricity.","long_description":"Build a wind turbine and test different blade designs to generate electricity.","long_description_for_teacher":"","short_description":"Build a wind turbine and test different blade designs to generate electricity.","class_name":"ExternalActivity","class_name_underscored":"external_activity","icon":{"url":"https://learn-resources.s3.amazonaws.com/images/stem-resources/icons/wind-generator.jpg"},"material_properties":[],"is_official":true,"is_archived":false,"is_favorite":false,"favorite_id":null,"subject_areas":["Engineering"],"grade_levels":["3","4"],"projects":[],"publication_status":"published","links":{"browse":{"url":"https://itsi.portal.concord.org/browse/eresources/22"},"preview":{"url":"https://itsi.portal.concord.org/eresources/22.run_resource_html","text":"Preview","target":"_blank"},"print_url":{"text":"Print","target":"_blank","url":"https://authoring.concord.org/activities/989/print_blank"}},"preview_url":"https://itsi.portal.concord.org/eresources/22.run_resource_html","edit_url":null,"unarchive_url":null,"archive_url":null,"copy_url":null,"assign_to_class_url":null,"assign_to_collection_url":null,"assigned_classes":[],"class_count":21,"sensors":[],"has_activities":false,"has_pretest":false,"saves_student_data":true,"activities":[],"lara_activity_or_sequence":true,"parent":null,"user":{"id":32,"name":"ITSI ITEST"},"assigned":false,"credits":null,"license_info":{"name":"Modifications YES, commercial use YES, sharing required  NO (CC-BY-4.0)","code":"CC-BY 4.0","deed":"http://creativecommons.org/licenses/by/4.0/","legal":"http://creativecommons.org/licenses/by/4.0/legalcode","image":"http://i.creativecommons.org/l/by/4.0/88x31.png","description":"This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.","number":1},"related_materials":[],"standard_statements":[],"enable_sharing":true,"slug":"wind-generator","stem_resource_url":"https://itsi.portal.concord.org/resources/22/wind-generator"}]},{"name":"Playground design","materials":[{"id":17,"name":"Building a Bungee Jump","long_description_for_current_user":"In this activity you will study and build a bungee jump that is safe and fun to use.","long_description":"In this activity you will study and build a bungee jump that is safe and fun to use.","long_description_for_teacher":"","short_description":"In this activity you will study and build a bungee jump that is safe and fun to use.","class_name":"ExternalActivity","class_name_underscored":"external_activity","icon":{"url":"https://learn-resources.concord.org/images/stem-resources/icons/bungee-jump.jpg"},"material_properties":[],"is_official":true,"is_archived":false,"is_favorite":false,"favorite_id":null,"subject_areas":["Engineering"],"grade_levels":["3","4"],"projects":[],"publication_status":"published","links":{"browse":{"url":"https://itsi.portal.concord.org/browse/eresources/17"},"preview":{"url":"https://itsi.portal.concord.org/eresources/17.run_resource_html","text":"Preview","target":"_blank"},"print_url":{"text":"Print","target":"_blank","url":"https://authoring.concord.org/activities/984/print_blank"}},"preview_url":"https://itsi.portal.concord.org/eresources/17.run_resource_html","edit_url":null,"unarchive_url":null,"archive_url":null,"copy_url":null,"assign_to_class_url":null,"assign_to_collection_url":null,"assigned_classes":[],"class_count":12,"sensors":[],"has_activities":false,"has_pretest":false,"saves_student_data":true,"activities":[],"lara_activity_or_sequence":true,"parent":null,"user":{"id":32,"name":"ITSI ITEST"},"assigned":false,"credits":null,"license_info":{"name":"Modifications YES, commercial use YES, sharing required  NO (CC-BY-4.0)","code":"CC-BY 4.0","deed":"http://creativecommons.org/licenses/by/4.0/","legal":"http://creativecommons.org/licenses/by/4.0/legalcode","image":"http://i.creativecommons.org/l/by/4.0/88x31.png","description":"This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.","number":1},"related_materials":[],"standard_statements":[],"enable_sharing":true,"slug":"building-a-bungee-jump","stem_resource_url":"https://itsi.portal.concord.org/resources/17/building-a-bungee-jump"}
+    ]
+  }
+]
+
 const mockedJQuery = () => ({
-  on: (message) => {}
+  on: (message) => {},
 });
 mockedJQuery.trim = (s) => s.trim()
+mockedJQuery.ajax = jest.fn().mockImplementation((options) => {
+  options.success(collectionsResult)
+})
 
 Enzyme.configure({adapter: new Adapter()})
 
@@ -95,6 +122,7 @@ describe('When I try to render materials-bin', () => {
           <div class="mb-cell mb-category mb-clickable   ">Cat B</div>
           <div class="mb-cell mb-category mb-clickable   ">Cat C</div>
           <div class="mb-cell mb-category mb-clickable   ">Cat D</div>
+          <div class="mb-cell mb-category mb-clickable   ">Cat E</div>
         </div>
         <div class="mb-column">
           <div class="mb-cell mb-category mb-clickable   mb-selected">Cat A1</div>
@@ -107,20 +135,23 @@ describe('When I try to render materials-bin', () => {
           <div class="mb-cell mb-hidden">
             <div>Loading...</div>
           </div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
+          </div>
         </div>
         <div class="mb-column">
-          <div class="mb-collection">
-            <div class="mb-collection-name"></div>
+          <div class="mb-cell ">
+            <div>Loading...</div>
           </div>
-          <div class="mb-collection">
-            <div class="mb-collection-name"></div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
           </div>
         </div>
       </div>
     `));
   });
 
-  it("should handle clicking of categories", () => {
+  it("should handle clicking of categories without collections", () => {
     const materialsBin = Enzyme.mount(<MaterialsBin materials={materials} />);
     const categoryB = materialsBin.find({slug: "cat-b"});
     categoryB.simulate("click")
@@ -133,6 +164,7 @@ describe('When I try to render materials-bin', () => {
           <div class="mb-cell mb-category mb-clickable   mb-selected">Cat B</div>
           <div class="mb-cell mb-category mb-clickable   ">Cat C</div>
           <div class="mb-cell mb-category mb-clickable   ">Cat D</div>
+          <div class="mb-cell mb-category mb-clickable   ">Cat E</div>
         </div>
         <div class="mb-column">
           <div class="mb-cell mb-category mb-clickable  mb-hidden ">Cat A1</div>
@@ -145,16 +177,145 @@ describe('When I try to render materials-bin', () => {
           <div class="mb-cell mb-hidden">
             <div>Loading...</div>
           </div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
+          </div>
         </div>
         <div class="mb-column">
-          <div class="mb-collection">
-            <div class="mb-collection-name"></div>
+          <div class="mb-cell mb-hidden">
+            <div class="mb-collection">
+              <div class="mb-collection-name">Collection</div>
+              <div class="mb-material">
+                <span class="mb-material-links">
+                  <a class="mb-toggle-info" href="" title="View activity description">
+                    <span class="mb-toggle-info-text">Info</span>
+                  </a>
+                  <a class="mb-run" href="https://itsi.portal.concord.org/eresources/21.run_resource_html" title="Run this activity in the browser">
+                    <span class="mb-run-text">Run</span>
+                  </a>
+                </span>
+                <span class="mb-material-name">Solar Oven</span>
+                <div class="mb-material-description mb-hidden">Design, build, and test a solar oven.</div>
+              </div>
+              <div class="mb-material">
+                <span class="mb-material-links">
+                  <a class="mb-toggle-info" href="" title="View activity description">
+                    <span class="mb-toggle-info-text">Info</span>
+                  </a>
+                  <a class="mb-run" href="https://itsi.portal.concord.org/eresources/22.run_resource_html" title="Run this activity in the browser">
+                    <span class="mb-run-text">Run</span>
+                  </a>
+                </span>
+                <span class="mb-material-name">Wind Generator</span>
+                <div class="mb-material-description mb-hidden">Build a wind turbine and test different blade designs to generate electricity.</div>
+              </div>
+            </div>
+            <div class="mb-collection">
+              <div class="mb-collection-name">Playground design</div>
+              <div class="mb-material">
+                <span class="mb-material-links">
+                  <a class="mb-toggle-info" href="" title="View activity description">
+                    <span class="mb-toggle-info-text">Info</span>
+                  </a>
+                  <a class="mb-run" href="https://itsi.portal.concord.org/eresources/17.run_resource_html" title="Run this activity in the browser">
+                    <span class="mb-run-text">Run</span>
+                  </a>
+                </span>
+                <span class="mb-material-name">Building a Bungee Jump</span>
+                <div class="mb-material-description mb-hidden">In this activity you will study and build a bungee jump that is safe and fun to use.</div>
+              </div>
+            </div>
           </div>
-          <div class="mb-collection">
-            <div class="mb-collection-name"></div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
           </div>
         </div>
       </div>
     `));
   });
+
+  it("should handle clicking of categories with collections", () => {
+    const materialsBin = Enzyme.mount(<MaterialsBin materials={materials} />);
+    const categoryE = materialsBin.find({slug: "cat-e"});
+    categoryE.simulate("click")
+    materialsBin.instance().checkHash()
+    materialsBin.update();
+    expect(materialsBin.html()).toBe(pack(`
+      <div class="materials-bin">
+        <div class="mb-column">
+          <div class="mb-cell mb-category mb-clickable custom-category-class  ">Cat A</div>
+          <div class="mb-cell mb-category mb-clickable   ">Cat B</div>
+          <div class="mb-cell mb-category mb-clickable   ">Cat C</div>
+          <div class="mb-cell mb-category mb-clickable   ">Cat D</div>
+          <div class="mb-cell mb-category mb-clickable   mb-selected">Cat E</div>
+        </div>
+        <div class="mb-column">
+          <div class="mb-cell mb-category mb-clickable  mb-hidden ">Cat A1</div>
+          <div class="mb-cell mb-category mb-clickable  mb-hidden ">Cat A2</div>
+          <div class="mb-cell mb-category mb-clickable  mb-hidden ">Cat B1</div>
+          <div class="mb-cell mb-category mb-clickable  mb-hidden ">Cat B2</div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
+          </div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
+          </div>
+          <div class="mb-cell ">
+            <div class="mb-collection">
+              <div class="mb-collection-name">Collection</div>
+              <a href="https://guides.itsi.concord.org/energy-production-teacher-guide.html" target="_blank">Teacher Guide</a>
+              <div class="mb-material">
+                <span class="mb-material-links">
+                  <a class="mb-toggle-info" href="" title="View activity description">
+                    <span class="mb-toggle-info-text">Info</span>
+                  </a>
+                  <a class="mb-run" href="https://itsi.portal.concord.org/eresources/21.run_resource_html" title="Run this activity in the browser">
+                    <span class="mb-run-text">Run</span>
+                  </a>
+                </span>
+                <span class="mb-material-name">Solar Oven</span>
+                <div class="mb-material-description mb-hidden">Design, build, and test a solar oven.</div>
+              </div>
+              <div class="mb-material">
+                <span class="mb-material-links">
+                  <a class="mb-toggle-info" href="" title="View activity description">
+                    <span class="mb-toggle-info-text">Info</span>
+                  </a>
+                  <a class="mb-run" href="https://itsi.portal.concord.org/eresources/22.run_resource_html" title="Run this activity in the browser">
+                    <span class="mb-run-text">Run</span>
+                  </a>
+                </span>
+                <span class="mb-material-name">Wind Generator</span>
+                <div class="mb-material-description mb-hidden">Build a wind turbine and test different blade designs to generate electricity.</div>
+              </div>
+            </div>
+            <div class="mb-collection">
+              <div class="mb-collection-name">Playground design</div>
+              <div class="mb-material">
+                <span class="mb-material-links">
+                  <a class="mb-toggle-info" href="" title="View activity description">
+                    <span class="mb-toggle-info-text">Info</span>
+                  </a>
+                  <a class="mb-run" href="https://itsi.portal.concord.org/eresources/17.run_resource_html" title="Run this activity in the browser">
+                    <span class="mb-run-text">Run</span>
+                  </a>
+                </span>
+                <span class="mb-material-name">Building a Bungee Jump</span>
+                <div class="mb-material-description mb-hidden">In this activity you will study and build a bungee jump that is safe and fun to use.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mb-column">
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
+          </div>
+          <div class="mb-cell mb-hidden">
+            <div>Loading...</div>
+          </div>
+        </div>
+      </div>
+    `));
+  });
+
 })


### PR DESCRIPTION
The outer materials-bin component loaded the (very similarly named) collections display component instead of the wrapper component that loaded the collection.

The tests have been updated to load the collections and code was added to detect if a category did not have collections (categories can optionally only have sub-categories) as without the collections the render code broke.